### PR TITLE
Add brackets around print() for python 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,9 @@ def get_package_data(package):
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     args = {'version': get_version(package)}
-    print "You probably want to also tag the version now:"
-    print "  git tag -a %(version)s -m 'version %(version)s'" % args
-    print "  git push --tags"
+    print("You probably want to also tag the version now:")
+    print("  git tag -a %(version)s -m 'version %(version)s'" % args)
+    print("  git push --tags")
     sys.exit()
 
 


### PR DESCRIPTION
The package doesn't install on python 3.4 because `setup.py` prints using

```
print "foo"
```

python3 removed the print statement and requires

```
print("foo")
```

All tests pass otherwise.
