### PR TITLE
Get unit tests to run again

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -6,9 +6,12 @@ import sys
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.settings')
 
+import django
 from django.core.management import call_command
 
 
 if __name__ == '__main__':
     args = sys.argv[1:]
+
+    django.setup()
     call_command('test', *args, verbosity=2, failfast=True)


### PR DESCRIPTION
- Call django.setup() to avoid AppRegistryNotReady exception